### PR TITLE
[FuzzMutate] CFG Strategies, including CFG splitter and PHI Node

### DIFF
--- a/llvm/include/llvm/FuzzMutate/IRMutator.h
+++ b/llvm/include/llvm/FuzzMutate/IRMutator.h
@@ -118,6 +118,34 @@ public:
   void mutate(Instruction &Inst, RandomIRBuilder &IB) override;
 };
 
+/// Strategy to split a random block and insert a random CFG in between.
+class CFGIRStrategy : public IRMutationStrategy {
+public:
+  uint64_t getWeight(size_t CurrentSize, size_t MaxSize,
+                     uint64_t CurrentWeight) override {
+    return 5;
+  }
+
+  using IRMutationStrategy::mutate;
+  void mutate(BasicBlock &BB, RandomIRBuilder &IB) override;
+
+private:
+  void connectBlocksToSink(ArrayRef<BasicBlock *> Blocks, BasicBlock *Sink,
+                           RandomIRBuilder &IB);
+};
+
+/// Strategy to insert PHI Nodes at the head of each basic block.
+class InsertPHIStrategy : public IRMutationStrategy {
+public:
+  uint64_t getWeight(size_t CurrentSize, size_t MaxSize,
+                     uint64_t CurrentWeight) override {
+    return 2;
+  }
+
+  using IRMutationStrategy::mutate;
+  void mutate(BasicBlock &BB, RandomIRBuilder &IB) override;
+};
+
 /// Fuzzer friendly interface for the llvm bitcode parser.
 ///
 /// \param Data Bitcode we are going to parse

--- a/llvm/include/llvm/FuzzMutate/RandomIRBuilder.h
+++ b/llvm/include/llvm/FuzzMutate/RandomIRBuilder.h
@@ -48,10 +48,12 @@ struct RandomIRBuilder {
   /// values in \c Srcs should be source operands that have already been
   /// selected.
   Value *findOrCreateSource(BasicBlock &BB, ArrayRef<Instruction *> Insts,
-                            ArrayRef<Value *> Srcs, fuzzerop::SourcePred Pred);
+                            ArrayRef<Value *> Srcs, fuzzerop::SourcePred Pred,
+                            bool AllowConstant = true);
   /// Create some Value suitable as a source for some operation.
   Value *newSource(BasicBlock &BB, ArrayRef<Instruction *> Insts,
-                   ArrayRef<Value *> Srcs, fuzzerop::SourcePred Pred);
+                   ArrayRef<Value *> Srcs, fuzzerop::SourcePred Pred,
+                   bool AllowConstant = true);
   /// Find a viable user for \c V in \c Insts, which should all be contained in
   /// \c BB. This may also create some new instruction in \c BB and use that.
   void connectToSink(BasicBlock &BB, ArrayRef<Instruction *> Insts, Value *V);
@@ -61,6 +63,8 @@ struct RandomIRBuilder {
                      ArrayRef<Value *> Srcs, fuzzerop::SourcePred Pred);
   Type *chooseType(LLVMContext &Context, ArrayRef<Value *> Srcs,
                    fuzzerop::SourcePred Pred);
+  /// Randomlly select a type from allowed types
+  Type *randomType();
 };
 
 } // end llvm namespace

--- a/llvm/lib/FuzzMutate/CMakeLists.txt
+++ b/llvm/lib/FuzzMutate/CMakeLists.txt
@@ -32,5 +32,6 @@ add_llvm_component_library(LLVMFuzzMutate
   Core
   Scalar
   Support
+  TransformUtils
   Target
   )

--- a/llvm/unittests/FuzzMutate/StrategiesTest.cpp
+++ b/llvm/unittests/FuzzMutate/StrategiesTest.cpp
@@ -319,4 +319,40 @@ TEST(InstModificationIRStrategyTest, DidntShuffleFRem) {
       }";
   VerfyDivDidntShuffle(Source);
 }
+
+TEST(CFGIRStrategy, CFG) {
+  LLVMContext Ctx;
+  StringRef Source = "\n\
+      define void @test(i1 %0, i1 %1, i1 %2, i1 %3, i16 %4, i16 %5, i32 %6) {\n\
+        Entry: \n\
+        ret void\n\
+      }";
+  auto Mutator = createMutator<CFGIRStrategy>();
+  ASSERT_TRUE(Mutator);
+
+  auto M = parseAssembly(Source.data(), Ctx);
+  srand(Seed);
+  for (int i = 0; i < 100; i++) {
+    Mutator->mutateModule(*M, rand(), Source.size(), Source.size() + 1024);
+    EXPECT_TRUE(!verifyModule(*M, &errs()));
+  }
+}
+
+TEST(InsertPHIStrategy, PHI) {
+  LLVMContext Ctx;
+  StringRef Source = "\n\
+      define void @test(i1 %0, i1 %1, i1 %2, i1 %3, i16 %4, i16 %5, i32 %6) {\n\
+        Entry: \n\
+        ret void\n\
+      }";
+  auto Mutator = createMutator<InsertPHIStrategy>();
+  ASSERT_TRUE(Mutator);
+
+  auto M = parseAssembly(Source.data(), Ctx);
+  srand(Seed);
+  for (int i = 0; i < 100; i++) {
+    Mutator->mutateModule(*M, rand(), Source.size(), Source.size() + 1024);
+    EXPECT_TRUE(!verifyModule(*M, &errs()));
+  }
+}
 }


### PR DESCRIPTION
…rtor.

Introduce a new way to split basic blocks without changing dominator tree. Introduce ret and switch instruction.
Introduce PHI node to take values from predecessor

Signed-off-by: Peter Rong <PeterRong96@gmail.com>

