### PR TITLE
[FuzzMutate] Make ShuffleBlockStrategy deterministic

### DIFF
--- a/llvm/lib/FuzzMutate/IRMutator.cpp
+++ b/llvm/lib/FuzzMutate/IRMutator.cpp
@@ -27,7 +27,6 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Transforms/Scalar/DCE.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
-#include <list>
 #include <map>
 #include <optional>
 

--- a/llvm/lib/FuzzMutate/IRMutator.cpp
+++ b/llvm/lib/FuzzMutate/IRMutator.cpp
@@ -613,10 +613,7 @@ void ShuffleBlockStrategy::mutate(BasicBlock &BB, RandomIRBuilder &IB) {
       RS.sample(Root, 1);
     Instruction *Root = RS.getSelection();
     Roots.remove(Root);
-    auto AIIter = std::find(AliveInsts.begin(), AliveInsts.end(), Root);
-    if (AIIter != AliveInsts.end()) {
-      AliveInsts.erase(AIIter);
-    }
+    AliveInsts.erase(std::find(AliveInsts.begin(), AliveInsts.end(), Root));
     Insts.push_back(Root);
     for (Instruction *Child : getAliveChildren(Root)) {
       if (!hasAliveParent(Child)) {


### PR DESCRIPTION
This PR replaces SmallPtrSet usage with either SmallVector or SmallSetVector to make iteration deterministic.