### PR TITLE
[FuzzMutate] Module size heuristics

### DIFF
--- a/llvm/include/llvm/FuzzMutate/IRMutator.h
+++ b/llvm/include/llvm/FuzzMutate/IRMutator.h
@@ -70,7 +70,8 @@ public:
       : AllowedTypes(std::move(AllowedTypes)),
         Strategies(std::move(Strategies)) {}
 
-  void mutateModule(Module &M, int Seed, size_t CurSize, size_t MaxSize);
+  static size_t getModuleSize(const Module &M);
+  void mutateModule(Module &M, int Seed, size_t MaxSize);
 };
 
 /// Strategy that injects operations into the function.

--- a/llvm/lib/FuzzMutate/IRMutator.cpp
+++ b/llvm/lib/FuzzMutate/IRMutator.cpp
@@ -27,7 +27,6 @@
 #include "llvm/Support/SourceMgr.h"
 #include "llvm/Transforms/Scalar/DCE.h"
 #include "llvm/Transforms/Utils/BasicBlockUtils.h"
-#include <list>
 #include <map>
 #include <optional>
 

--- a/llvm/lib/FuzzMutate/IRMutator.cpp
+++ b/llvm/lib/FuzzMutate/IRMutator.cpp
@@ -613,10 +613,7 @@ void ShuffleBlockStrategy::mutate(BasicBlock &BB, RandomIRBuilder &IB) {
       RS.sample(Root, 1);
     Instruction *Root = RS.getSelection();
     Roots.remove(Root);
-    auto AIIter = std::find(AliveInsts.begin(), AliveInsts.end(), Root);
-    if (AIIter != AliveInsts.end()) {
-      AliveInsts.erase(AIIter);
-    }
+    AliveInsts.erase(std::find(AliveInsts.begin(), AliveInsts.end(), Root));
     Insts.push_back(Root);
     for (Instruction *Child : getAliveChildren(Root)) {
       if (!hasAliveParent(Child)) {

--- a/llvm/tools/llvm-stress/llvm-stress.cpp
+++ b/llvm/tools/llvm-stress/llvm-stress.cpp
@@ -178,7 +178,7 @@ int main(int argc, char **argv) {
   srand(Seed);
   auto Mutator = createCustomMutator();
   for (unsigned i = 0; i < RepeatCL; i++) {
-    Mutator->mutateModule(*M, rand(), M->size(), MaxSizeCL);
+    Mutator->mutateModule(*M, rand(), MaxSizeCL);
   }
 
   // Figure out what stream we are supposed to write to...


### PR DESCRIPTION
Use the number of objects (i.e. BBs, functions, instructions, aliases) as a rough measure for Module size instead of bitcode size.