### PR TITLE
[TableGen][DAGISel] Add pattern lookup table generation

### DIFF
--- a/llvm/utils/TableGen/DAGISelMatcherEmitter.cpp
+++ b/llvm/utils/TableGen/DAGISelMatcherEmitter.cpp
@@ -960,7 +960,9 @@ EmitMatcherList(const Matcher *N, const unsigned Indent, unsigned CurrentIdx,
       json::Object TheMatcher;
       TheMatcher["index"] = CurrentIdx;
       TheMatcher["size"] = MatcherSize;
-      TheMatcher["pattern"] = LastPatternIdx;
+      TheMatcher["kind"] = static_cast<int>(N->getKind());
+      if (N->getKind() == Matcher::MorphNodeTo || N->getKind() == Matcher::CompleteMatch)
+        TheMatcher["pattern"] = LastPatternIdx;
       Matchers.push_back(json::Value(std::move(TheMatcher)));
     }
 


### PR DESCRIPTION
This PR adds `-pattern-lookup` to llvm-tblgen, which can be used with `-gen-dag-isel` to generate a lookup table in JSON. This lookup table contains a list of matchers, patterns, and predicates, which can be useful in analyzing matcher table coverage.