### PR TITLE
[FuzzMutate] Allow customizing function selection in InsertFunctionStrategy

### DIFF
--- a/llvm/include/llvm/FuzzMutate/IRMutator.h
+++ b/llvm/include/llvm/FuzzMutate/IRMutator.h
@@ -145,6 +145,8 @@ public:
 
   using IRMutationStrategy::mutate;
   void mutate(BasicBlock &BB, RandomIRBuilder &IB) override;
+
+  virtual Function *chooseFunction(Module *M, RandomIRBuilder &IB);
 };
 
 /// Strategy to split a random block and insert a random CFG in between.

--- a/llvm/include/llvm/FuzzMutate/IRMutator.h
+++ b/llvm/include/llvm/FuzzMutate/IRMutator.h
@@ -146,6 +146,11 @@ public:
   using IRMutationStrategy::mutate;
   void mutate(BasicBlock &BB, RandomIRBuilder &IB) override;
 
+protected:
+  /// @brief Chooses a function to call from the given module
+  /// @param M module from which a function is selected
+  /// @param IB random IR builder
+  /// @return the function to call, or nullptr to create a new function declaration
   virtual Function *chooseFunction(Module *M, RandomIRBuilder &IB);
 };
 

--- a/llvm/lib/FuzzMutate/IRMutator.cpp
+++ b/llvm/lib/FuzzMutate/IRMutator.cpp
@@ -386,16 +386,19 @@ static uint64_t getUniqueCaseValue(SmallSet<uint64_t, 4> &CasesTaken,
   return tmp;
 }
 
-void InsertFunctionStrategy::mutate(BasicBlock &BB, RandomIRBuilder &IB) {
-  Module *M = BB.getParent()->getParent();
+Function *InsertFunctionStrategy::chooseFunction(Module *M, RandomIRBuilder &IB) {
   // If nullptr is selected, we will create a new function declaration.
   SmallVector<Function *, 32> Functions({nullptr});
   for (Function &F : M->functions()) {
     Functions.push_back(&F);
   }
-
   auto RS = makeSampler(IB.Rand, Functions);
-  Function *F = RS.getSelection();
+  return RS.getSelection();
+}
+
+void InsertFunctionStrategy::mutate(BasicBlock &BB, RandomIRBuilder &IB) {
+  Module *M = BB.getParent()->getParent();
+  Function *F = chooseFunction(M, IB);
   // Some functions accept metadata type or token type as arguments.
   // We don't call those functions for now.
   // For example, `@llvm.dbg.declare(metadata, metadata, metadata)`


### PR DESCRIPTION
This PR allows subclasses of InsertFunctionStrategy to customize how the function to be called is chosen.

By the way, should I submit a revision to LLVM, or should we keep the change within IRFuzzer? 